### PR TITLE
Fix various bugs in webserver

### DIFF
--- a/HeishaMon/src/common/webserver.h
+++ b/HeishaMon/src/common/webserver.h
@@ -93,7 +93,7 @@ struct WiFiClient {
 
 typedef struct webserver_t {
   tcp_pcb *pcb;
-  WiFiClient client;
+  WiFiClient *client;
   unsigned long lastseen;
   uint8_t active:1;
   uint8_t reqtype:1;
@@ -112,6 +112,7 @@ typedef struct webserver_t {
   webserver_cb_t *callback;
   unsigned char buffer[WEBSERVER_BUFFER_SIZE];
   char *boundary;
+  void *userdata;
 } webserver_t;
 
 typedef struct webserver_client_t {


### PR DESCRIPTION
```c
-----------------------------354617515641648399072235817744\r\n
Content-Disposition: form-data; name="rules"\r\n
\r\n
on ds18b20#28610695f0013c42 then\r\n
  #foo = ds18b20#28610695f0013c42;\r\n
end\r\n
\r\n
on ?setpoint then\r\n
  #bar = ?setpoint;\r\n
end\r\n
-----------------------------354617515641648399072235817744--\r\n
\r\n
```

The webserver detects `\r\n--` chunks as possible boundary delimiters. However, when a chunks splits the `\r\n` and `--` tokens the `\r\n` is added to the content and not seen as a potential boundary delimiter. This commit fixes that.

----

Secondly, this fixes the bug were the WiFiClient instance wasn't stored in the heap but lived inside the local scope:
```diff
-       clients[i].data.client = sync_server.available();
+       clients[i].data.client = new WiFiClient(sync_server.available());
```