### PR TITLE
Added rule ceil and floor functions

### DIFF
--- a/HeishaMon/src/rules/function.cpp
+++ b/HeishaMon/src/rules/function.cpp
@@ -29,6 +29,8 @@
 #include "functions/max.h"
 #include "functions/min.h"
 #include "functions/coalesce.h"
+#include "functions/ceil.h"
+#include "functions/floor.h"
 #include "functions/settimer.h"
 #include "functions/isset.h"
 #include "functions/round.h"
@@ -36,6 +38,8 @@
 struct rule_function_t rule_functions[] = {
   { "max", rule_function_max_callback },
   { "min", rule_function_min_callback },
+  { "ceil", rule_function_ceil_callback },
+  { "floor", rule_function_floor_callback },
   { "coalesce", rule_function_coalesce_callback },
   { "settimer", rule_function_set_timer_callback },
   { "isset", rule_function_isset_callback },

--- a/HeishaMon/src/rules/functions/ceil.cpp
+++ b/HeishaMon/src/rules/functions/ceil.cpp
@@ -1,0 +1,58 @@
+/*
+  Copyright (C) CurlyMo
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#ifdef ESP8266
+  #pragma GCC diagnostic warning "-fpermissive"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+#include "../function.h"
+#include "../../common/mem.h"
+#include "../rules.h"
+
+int rule_function_ceil_callback(struct rules_t *obj, uint16_t argc, uint16_t *argv, int *ret) {
+/* LCOV_EXCL_START*/
+#ifdef DEBUG
+  printf("%s\n", __FUNCTION__);
+#endif
+/* LCOV_EXCL_STOP*/
+
+  if(argc != 1) {
+    return -1;
+  }
+
+  *ret = obj->varstack.nrbytes;
+
+  unsigned int size = alignedbytes(obj->varstack.nrbytes+sizeof(struct vm_vinteger_t));
+  if((obj->varstack.buffer = (unsigned char *)REALLOC(obj->varstack.buffer, alignedbuffer(size))) == NULL) {
+    OUT_OF_MEMORY /*LCOV_EXCL_LINE*/
+  }
+  struct vm_vinteger_t *out = (struct vm_vinteger_t *)&obj->varstack.buffer[obj->varstack.nrbytes];
+  out->ret = 0;
+  out->type = VINTEGER;
+
+  switch(obj->varstack.buffer[argv[0]]) {
+    case VINTEGER: {
+      struct vm_vinteger_t *val = (struct vm_vinteger_t *)&obj->varstack.buffer[argv[0]];
+      out->value = val->value;
+    } break;
+    case VFLOAT: {
+      struct vm_vfloat_t *val = (struct vm_vfloat_t *)&obj->varstack.buffer[argv[0]];
+      out->value = (int)ceil(val->value);
+    } break;
+  }
+
+  obj->varstack.nrbytes = size;
+  obj->varstack.bufsize = alignedbuffer(size);
+
+  return 0;
+}

--- a/HeishaMon/src/rules/functions/ceil.h
+++ b/HeishaMon/src/rules/functions/ceil.h
@@ -1,0 +1,17 @@
+/*
+  Copyright (C) CurlyMo
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#ifndef _RULES_CEIL_H_
+#define _RULES_CEIL_H_
+
+#include <stdint.h>
+#include "../rules.h"
+
+int rule_function_ceil_callback(struct rules_t *obj, uint16_t argc, uint16_t *argv, int *ret);
+
+#endif

--- a/HeishaMon/src/rules/functions/floor.cpp
+++ b/HeishaMon/src/rules/functions/floor.cpp
@@ -1,0 +1,58 @@
+/*
+  Copyright (C) CurlyMo
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#ifdef ESP8266
+  #pragma GCC diagnostic warning "-fpermissive"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+#include "../function.h"
+#include "../../common/mem.h"
+#include "../rules.h"
+
+int rule_function_floor_callback(struct rules_t *obj, uint16_t argc, uint16_t *argv, int *ret) {
+/* LCOV_EXCL_START*/
+#ifdef DEBUG
+  printf("%s\n", __FUNCTION__);
+#endif
+/* LCOV_EXCL_STOP*/
+
+  if(argc != 1) {
+    return -1;
+  }
+
+  *ret = obj->varstack.nrbytes;
+
+  unsigned int size = alignedbytes(obj->varstack.nrbytes+sizeof(struct vm_vinteger_t));
+  if((obj->varstack.buffer = (unsigned char *)REALLOC(obj->varstack.buffer, alignedbuffer(size))) == NULL) {
+    OUT_OF_MEMORY /*LCOV_EXCL_LINE*/
+  }
+  struct vm_vinteger_t *out = (struct vm_vinteger_t *)&obj->varstack.buffer[obj->varstack.nrbytes];
+  out->ret = 0;
+  out->type = VINTEGER;
+
+  switch(obj->varstack.buffer[argv[0]]) {
+    case VINTEGER: {
+      struct vm_vinteger_t *val = (struct vm_vinteger_t *)&obj->varstack.buffer[argv[0]];
+      out->value = val->value;
+    } break;
+    case VFLOAT: {
+      struct vm_vfloat_t *val = (struct vm_vfloat_t *)&obj->varstack.buffer[argv[0]];
+      out->value = (int)floor(val->value);
+    } break;
+  }
+
+  obj->varstack.nrbytes = size;
+  obj->varstack.bufsize = alignedbuffer(size);
+
+  return 0;
+}

--- a/HeishaMon/src/rules/functions/floor.h
+++ b/HeishaMon/src/rules/functions/floor.h
@@ -1,0 +1,17 @@
+/*
+  Copyright (C) CurlyMo
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#ifndef _RULES_FLOOR_H_
+#define _RULES_FLOOR_H_
+
+#include <stdint.h>
+#include "../rules.h"
+
+int rule_function_floor_callback(struct rules_t *obj, uint16_t argc, uint16_t *argv, int *ret);
+
+#endif

--- a/README.md
+++ b/README.md
@@ -152,6 +152,12 @@ Return boolean true when the input variable is still `NULL` in any other cases i
 - `round`
 Rounds the input float to the nearest integer.
 
+- `floor`
+The largest integer value less than or equal to the input float.
+
+- `ceil`
+The smallest integer value greater than or equal to the input float.
+
 - `setTimer`
 Sets a timer to trigger in X seconds. The first parameter is the timer number and the second parameters the number of seconds before it fires. A timer only fires once so it has to be re-set for recurring events. When a timer triggers it will can the timer event as described above.
 


### PR DESCRIPTION
To calculate the requested heating temperature based on HeishaMon values, the ceil functionality is necessary. The actual calculation is done like this:

```
ceil(@Z1_Heat_Curve_Target_Low_Temp +
 (
   (@Z1_Heat_Curve_Outside_High_Temp - @Outside_Temp) *
   (@Z1_Heat_Curve_Target_High_Temp - @Z1_Heat_Curve_Target_Low_Temp) /
   (@Z1_Heat_Curve_Outside_High_Temp - @Z1_Heat_Curve_Outside_Low_Temp)
  )
);
```