### PR TITLE
Allow Heishamon restart using MQTT

### DIFF
--- a/HeishaMon/HeishaMon.ino
+++ b/HeishaMon/HeishaMon.ino
@@ -467,6 +467,8 @@ void mqtt_callback(char* topic, byte* payload, unsigned int length) {
       openTherm[1] = cpy;
 
       rules_event_cb("setpoint");
+    } else if (stricmp((char const *)topic, "panasonic_heat_pump/restart") == 0) {
+      ESP.restart();
     }
     mqttcallbackinprogress = false;
   }


### PR DESCRIPTION
I'm in a scenario where the webserver fails so the only
way to restart it remotely is by switching power of the
heatpump. In my case MQTT still works, so it would be
handy if we could restart the Heishamon using a MQTT
command.